### PR TITLE
use MultiBzDecoder instead of BzDecoder for bzip2 streams

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ azure-devops = { project = "cmchenry/wikidump", pipeline = "camchenry.wikidump",
 quick-xml = "0.16.1"
 parse_wiki_text = "0.1.5"
 rayon = "1.2.0"
-bzip2 = "0.3.3"
+bzip2 = "0.4.4"
 
 [dev-dependencies]
 criterion = "0.3.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,7 @@
 //! ```
 
 pub mod config;
-use bzip2::read::BzDecoder;
+use bzip2::read::MultiBzDecoder;
 use parse_wiki_text::{Configuration, ConfigurationSource, Node};
 use quick_xml::events::Event;
 use quick_xml::Reader;
@@ -229,7 +229,7 @@ impl Parser {
     {
         if is_compressed(&dump) {
             let file = File::open(dump)?;
-            let reader = BufReader::new(BzDecoder::new(file));
+            let reader = BufReader::new(MultiBzDecoder::new(file));
             let reader = Reader::from_reader(reader);
 
             self.parse(reader)


### PR DESCRIPTION
Otherwise, [large wikipedia dumps can't be read](https://docs.rs/bzip2/0.4.4/bzip2/read/struct.MultiBzDecoder.html).